### PR TITLE
Change overleaf template url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A modern LaTeX class file for typesetting a thesis at the University of Iowa.
 There is an [overleaf
-template](https://www.overleaf.com/latex/templates/uiowa-thesis/nspcwqkmvcnq)
+template](https://www.overleaf.com/docs?snip_uri=https://github.com/uiowa-mgb/uiowa-thesis/releases/latest/download/thesis.zip)
 alternatively see [the release
 page](https://github.com/uiowa-mgb/uiowa-thesis/releases) to download a working
 example to base your thesis on. If you have any questions the [faq](notes/faq.md) may


### PR DESCRIPTION
Currently we link to an overleaf template which is hosted on the overleaf gallery here https://www.overleaf.com/latex/templates/uiowa-thesis/nspcwqkmvcnq this has some issues:

- They have messed with it in the past. Without notifying us in any way they changed it to link to a different template because "they looked similar"
- [the process to update it](https://de.overleaf.com/learn/how-to/Publishing_templates_and_examples_in_the_Overleaf_Gallery) is very manual, requiring you to log into overleaf, create a project, upload the project to the gallery, respond to an email, and await manual approval

It turns out they have another mechanism for templates documented here https://www.overleaf.com/devs. In short the following url:
```
https://www.overleaf.com/docs?snip_uri=https://github.com/uiowa-mgb/uiowa-thesis/releases/latest/download/thesis.zip
```
will cause overleaf to download the most recent template from github and open it as a new project. This feels preferable to me. The only thing we lose out on is the ability for people to search for our template on overleaf proper.

It does also prompt the question what to do with our template which is already on overleaf.