### PR TITLE
Fix: overfull hbox in TOC

### DIFF
--- a/uiowa-thesis.cls
+++ b/uiowa-thesis.cls
@@ -46,6 +46,8 @@
 \LoadClass{memoir}
 \pagestyle{plain}
 
+\cftlocalchange{toc}{3.5em}{2.5em}
+
 \RequirePackage{biblatex}
 
 % Defining a new chapter style 


### PR DESCRIPTION
When you have 3-digit bold page numbers in your TOC, you get overfull hboxes.

## Bad

<img width="702" height="926" alt="Screenshot_27-4-2026_223312_www overleaf com" src="https://github.com/user-attachments/assets/38dfddfe-7417-4edc-ba13-a61e8f547e14" />

This PR fixes that.

## Good

<img width="700" height="927" alt="Screenshot_27-4-2026_223812_www overleaf com" src="https://github.com/user-attachments/assets/ac7965b5-129e-4d7f-bdaa-9d2859047487" />

## BUT!

If your thesis spills into 1000+ pages, this probably happens again. So don't do that.

[Reference](https://tex.stackexchange.com/questions/652332/overfull-hbox-in-toc-caused-by-bold-text)
